### PR TITLE
Allow renovatebot to update external-secrets [ACC-2092]

### DIFF
--- a/contentgrid-junit-jupiter-k8s/src/main/java/com/contentgrid/junit/jupiter/externalsecrets/ExternalSecretsExtension.java
+++ b/contentgrid-junit-jupiter-k8s/src/main/java/com/contentgrid/junit/jupiter/externalsecrets/ExternalSecretsExtension.java
@@ -46,8 +46,9 @@ public class ExternalSecretsExtension implements HasHelmClient, HasKubernetesCli
         var helm = getHelmClient(context);
         // setup external-secrets-operator
         helm.repository().add("external-secrets", "https://charts.external-secrets.io");
-        helm.dependency().build(ExternalSecretsExtension.class.getResource("/externalsecrets/chart").getPath());
-        helm.install().chart("external-secrets", ExternalSecretsExtension.class.getResource("/externalsecrets/chart").getPath());
+        var chartPath = ExternalSecretsExtension.class.getResource("/externalsecrets/chart").getPath();
+        helm.dependency().build(chartPath);
+        helm.install().chart("external-secrets", chartPath);
 
         // wait until expected deployments have available-replica
         waitUntilDeploymentsReady(2 * 60,

--- a/contentgrid-junit-jupiter-k8s/src/main/java/com/contentgrid/junit/jupiter/externalsecrets/ExternalSecretsExtension.java
+++ b/contentgrid-junit-jupiter-k8s/src/main/java/com/contentgrid/junit/jupiter/externalsecrets/ExternalSecretsExtension.java
@@ -5,7 +5,6 @@ import static com.contentgrid.junit.jupiter.k8s.K8sTestUtils.isCiliumNetworkPoli
 import static com.contentgrid.junit.jupiter.k8s.K8sTestUtils.waitUntilDeploymentsReady;
 import static org.apache.commons.lang3.RandomStringUtils.insecure;
 
-import com.contentgrid.helm.HelmInstallCommand.InstallOption;
 import com.contentgrid.junit.jupiter.helm.HasHelmClient;
 import io.fabric8.junit.jupiter.HasKubernetesClient;
 import java.lang.reflect.Field;
@@ -47,7 +46,8 @@ public class ExternalSecretsExtension implements HasHelmClient, HasKubernetesCli
         var helm = getHelmClient(context);
         // setup external-secrets-operator
         helm.repository().add("external-secrets", "https://charts.external-secrets.io");
-        helm.install().chart("external-secrets", "external-secrets/external-secrets", InstallOption.version("v0.16.2"));
+        helm.dependency().build(ExternalSecretsExtension.class.getResource("/externalsecrets/chart").getPath());
+        helm.install().chart("external-secrets", ExternalSecretsExtension.class.getResource("/externalsecrets/chart").getPath());
 
         // wait until expected deployments have available-replica
         waitUntilDeploymentsReady(2 * 60,

--- a/contentgrid-junit-jupiter-k8s/src/main/resources/externalsecrets/chart/Chart.yaml
+++ b/contentgrid-junit-jupiter-k8s/src/main/resources/externalsecrets/chart/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v2
+version: 0.1.0
+name: ExternalSecretsRenovateTarget
+description: "This chart is just for installing external-secrets, it's in a separate chart so that renovatebot can update the version of external-secrets."
+dependencies:
+  - name: external-secrets
+    version: 0.16.2
+    repository: "https://charts.external-secrets.io/"


### PR DESCRIPTION
Putting external-secrets in a chart with a version allows renovatebot to discover the dependency and send pull requests to update it.