### PR TITLE
remove log from helm install

### DIFF
--- a/contentgrid-helm-client/src/main/java/com/contentgrid/helm/impl/CommandExecutor.java
+++ b/contentgrid-helm-client/src/main/java/com/contentgrid/helm/impl/CommandExecutor.java
@@ -5,6 +5,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
 
 public interface CommandExecutor {
 

--- a/contentgrid-helm-client/src/main/java/com/contentgrid/helm/impl/DefaultHelmInstallCommand.java
+++ b/contentgrid-helm-client/src/main/java/com/contentgrid/helm/impl/DefaultHelmInstallCommand.java
@@ -14,9 +14,7 @@ import java.util.Map.Entry;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
-import lombok.extern.slf4j.Slf4j;
 
-@Slf4j
 @RequiredArgsConstructor
 class DefaultHelmInstallCommand implements HelmInstallCommand {
 
@@ -55,8 +53,6 @@ class DefaultHelmInstallCommand implements HelmInstallCommand {
         args.addAll(List.of("--output", "json"));
 
         var stdout = this.executor.call(CMD_INSTALL, args);
-
-        log.info(stdout);
 
         return this.objectMapper.readValue(stdout, DefaultInstallResult.class);
     }

--- a/contentgrid-helm-client/src/main/java/com/contentgrid/helm/impl/DefaultHelmListCommand.java
+++ b/contentgrid-helm-client/src/main/java/com/contentgrid/helm/impl/DefaultHelmListCommand.java
@@ -12,9 +12,7 @@ import java.util.List;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
-import lombok.extern.slf4j.Slf4j;
 
-@Slf4j
 @RequiredArgsConstructor
 public class DefaultHelmListCommand implements HelmListCommand {
 
@@ -39,7 +37,6 @@ public class DefaultHelmListCommand implements HelmListCommand {
         args.addAll(List.of("--time-format", RFC3339));
 
         var stdout = String.join(System.lineSeparator(), this.executor.call(CMD_LIST, args));
-        log.info("{}{}", System.lineSeparator(), stdout);
 
         return objectMapper.readValue(stdout, RELEASES_TYPEREF)
                 .stream().map(HelmRelease.class::cast).toList();

--- a/contentgrid-helm-client/src/main/java/com/contentgrid/helm/impl/DefaultHelmTemplateCommand.java
+++ b/contentgrid-helm-client/src/main/java/com/contentgrid/helm/impl/DefaultHelmTemplateCommand.java
@@ -9,9 +9,7 @@ import java.util.List;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
-import lombok.extern.slf4j.Slf4j;
 
-@Slf4j
 @RequiredArgsConstructor
 class DefaultHelmTemplateCommand implements HelmTemplateCommand {
 
@@ -47,8 +45,6 @@ class DefaultHelmTemplateCommand implements HelmTemplateCommand {
         });
 
         var stdout = this.executor.call(CMD_TEMPLATE, args);
-
-        log.debug(System.lineSeparator() + stdout);
 
         return new TemplateResult(stdout);
     }

--- a/contentgrid-helm-client/src/main/java/com/contentgrid/helm/impl/ProcessBuilderHelmExecutor.java
+++ b/contentgrid-helm-client/src/main/java/com/contentgrid/helm/impl/ProcessBuilderHelmExecutor.java
@@ -35,7 +35,7 @@ class ProcessBuilderHelmExecutor implements CommandExecutor {
         builder.environment().putAll(this.environment);
         builder.directory(this.workingDirectory);
 
-        log.info("$ {} {}",
+        log.debug("$ {} {}",
                 this.environment.entrySet().stream()
                         .map(entry -> entry.getKey() + "=" + entry.getValue())
                         .collect(Collectors.joining(" ")),
@@ -47,5 +47,14 @@ class ProcessBuilderHelmExecutor implements CommandExecutor {
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
+    }
+
+    @Override
+    public String call(String command, List<String> args) throws CommandException {
+        var stdout = CommandExecutor.super.call(command, args);
+
+        log.debug("{}", stdout);
+
+        return stdout;
     }
 }


### PR DESCRIPTION
Logging the full output of helm install is a bit much, it spews so much output that the test logs become quite unreadable.

Instead, log at debug level, directly in the command executor
