### PR TITLE
Introduce `@HelmChart`/`HelmChartHandle` API for easily installing helm charts

### DIFF
--- a/contentgrid-helm-client/src/main/java/com/contentgrid/helm/Helm.java
+++ b/contentgrid-helm-client/src/main/java/com/contentgrid/helm/Helm.java
@@ -13,6 +13,8 @@ public interface Helm {
 
     HelmInstallCommand install();
 
+    HelmUninstallCommand uninstall();
+
     HelmTemplateCommand template();
 
     /**

--- a/contentgrid-helm-client/src/main/java/com/contentgrid/helm/HelmDependencyCommand.java
+++ b/contentgrid-helm-client/src/main/java/com/contentgrid/helm/HelmDependencyCommand.java
@@ -1,15 +1,20 @@
 package com.contentgrid.helm;
 
-import com.contentgrid.helm.HelmInstallCommand.InstallOption;
-import com.contentgrid.helm.HelmInstallCommand.InstallResult;
 import java.net.URI;
 import java.nio.file.Path;
 import java.util.List;
-import lombok.Value;
 
 public interface HelmDependencyCommand {
 
-    List<HelmDependency> list();
+    List<HelmDependency> list(String chart);
+
+    default List<HelmDependency> list(Path chartPath) {
+        return list(chartPath.toAbsolutePath().normalize().toString());
+    }
+
+    default List<HelmDependency> list() {
+        return list(".");
+    }
 
     void build(String chart);
 

--- a/contentgrid-helm-client/src/main/java/com/contentgrid/helm/HelmInstallCommand.java
+++ b/contentgrid-helm-client/src/main/java/com/contentgrid/helm/HelmInstallCommand.java
@@ -1,11 +1,19 @@
 package com.contentgrid.helm;
 
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.Map;
 
 public interface HelmInstallCommand {
 
 
+    /**
+     * Install helm chart referenced by a local path to a packaged or unpacked chart.
+     *
+     * @param name of the helm release
+     * @param chart a chart reference, a path to a packaged chart, a path to an unpacked chart directory or a URL
+     * @param options install flags
+     */
     InstallResult chart(String name, String chart, InstallOption... options);
 
     /**
@@ -14,7 +22,6 @@ public interface HelmInstallCommand {
      * @param name of the helm release
      * @param chartPath path to the chart
      * @param options install flags
-     * @return
      */
     default InstallResult chart(String name, Path chartPath, InstallOption... options) {
         return this.chart(name, chartPath.toAbsolutePath().normalize().toString(), options);
@@ -23,15 +30,21 @@ public interface HelmInstallCommand {
     /**
      * Install the referenced chart, with --generate-name implied
      *
-     * @param chart - a chart reference, a path to a packaged chart, a path to an unpacked chart directory or a URL
+     * @param chart a chart reference, a path to a packaged chart, a path to an unpacked chart directory or a URL
+     * @param options additional installation options
      */
-    default InstallResult chart(String chart) {
-        return this.chart(null, chart, InstallOption.generateName());
+    default InstallResult chart(String chart, InstallOption... options) {
+        var installOptions = Arrays.copyOf(options, options.length+1);
+        installOptions[options.length] = InstallOption.generateName();
+        return this.chart(null, chart, installOptions);
     }
 
     /**
      * Install the chart from the current working directory, with --generate-name implied
+     *
+     * @deprecated This confusingly-named function can be replaced by {@code .chart(".")}
      */
+    @Deprecated(since = "0.0.8", forRemoval = true)
     default InstallResult cwd() {
         return this.chart(".");
     }

--- a/contentgrid-helm-client/src/main/java/com/contentgrid/helm/HelmUninstallCommand.java
+++ b/contentgrid-helm-client/src/main/java/com/contentgrid/helm/HelmUninstallCommand.java
@@ -1,0 +1,58 @@
+package com.contentgrid.helm;
+
+public interface HelmUninstallCommand {
+
+    /**
+     * Uninstall helm chart
+     *
+     * @param name of the helm release
+     * @param options uninstall flags
+     */
+    UninstallResult uninstall(String name, UninstallOption... options);
+
+
+    interface UninstallOption {
+        void apply(UninstallOptionsHandler handler);
+
+        /**
+         * Untyped arguments appended to the command. Main use case is adding less-common flags.
+         */
+        static UninstallOption arguments(String... args) {
+            return handler -> handler.arguments(args);
+        }
+
+        /**
+         * Simulate an uninstall, implying '--dry-run=client', no cluster connections will be attempted.
+         */
+        static UninstallOption dryRun() {
+            return handler -> handler.dryRun();
+        }
+
+        /**
+         * Kubernetes namespace scope for this request
+         * @param namespace kubernetes namespace
+         */
+        static UninstallOption namespace(String namespace) {
+            return handler -> handler.namespace(namespace);
+        }
+
+        /**
+         * Time to wait for any individual Kubernetes operation. (default "5m0s")
+         * @param duration timeout expression
+         */
+        static UninstallOption timeout(String duration) {
+            return handler -> handler.timeout(duration);
+        }
+    }
+
+    interface UninstallOptionsHandler {
+        void namespace(String namespace);
+        void timeout(String duration);
+        void dryRun();
+        void arguments(String ... args);
+    }
+
+    interface UninstallResult {
+
+    }
+}

--- a/contentgrid-helm-client/src/main/java/com/contentgrid/helm/impl/DefaultHelm.java
+++ b/contentgrid-helm-client/src/main/java/com/contentgrid/helm/impl/DefaultHelm.java
@@ -6,6 +6,7 @@ import com.contentgrid.helm.HelmInstallCommand;
 import com.contentgrid.helm.HelmListCommand;
 import com.contentgrid.helm.HelmRepositoryCommand;
 import com.contentgrid.helm.HelmTemplateCommand;
+import com.contentgrid.helm.HelmUninstallCommand;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Map;
 import lombok.NonNull;
@@ -42,6 +43,11 @@ class DefaultHelm implements Helm {
     @Override
     public HelmInstallCommand install() {
         return new DefaultHelmInstallCommand(this.executor, this.objectMapper);
+    }
+
+    @Override
+    public HelmUninstallCommand uninstall() {
+        return new DefaultHelmUninstallCommand(this.executor);
     }
 
     @Override

--- a/contentgrid-helm-client/src/main/java/com/contentgrid/helm/impl/DefaultHelmDependencyCommand.java
+++ b/contentgrid-helm-client/src/main/java/com/contentgrid/helm/impl/DefaultHelmDependencyCommand.java
@@ -20,8 +20,8 @@ class DefaultHelmDependencyCommand implements HelmDependencyCommand {
 
     @Override
     @SneakyThrows
-    public List<HelmDependency> list() {
-        return Arrays.stream(this.executor.call(CMD_DEPENDENCY, "list").split(System.lineSeparator()))
+    public List<HelmDependency> list(String chart) {
+        return Arrays.stream(this.executor.call(CMD_DEPENDENCY, "list", chart).split(System.lineSeparator()))
                 .skip(1) // skip header
                 .filter(Objects::nonNull)
                 .map(line -> line.split("\\s+"))

--- a/contentgrid-helm-client/src/main/java/com/contentgrid/helm/impl/DefaultHelmUninstallCommand.java
+++ b/contentgrid-helm-client/src/main/java/com/contentgrid/helm/impl/DefaultHelmUninstallCommand.java
@@ -1,0 +1,63 @@
+package com.contentgrid.helm.impl;
+
+import com.contentgrid.helm.HelmUninstallCommand;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
+
+@RequiredArgsConstructor
+public class DefaultHelmUninstallCommand implements HelmUninstallCommand {
+
+    private static final String CMD_UNINSTALL = "uninstall";
+
+    @NonNull
+    private final CommandExecutor executor;
+
+    @Override
+    @SneakyThrows
+    public UninstallResult uninstall(@NonNull String name, UninstallOption... options) {
+        List<String> args = new ArrayList<>();
+        args.add(name);
+
+        var handler = new DefaultUninstallOptionsHandler(args);
+        for (var option : options) {
+            option.apply(handler);
+        }
+
+        executor.call(CMD_UNINSTALL, args);
+
+        return new UninstallResult() {
+        };
+    }
+
+    @RequiredArgsConstructor
+    private static class DefaultUninstallOptionsHandler implements UninstallOptionsHandler {
+        @NonNull
+        protected final List<String> arguments;
+
+        @Override
+        public void namespace(String namespace) {
+            arguments.add("--namespace");
+            arguments.add(namespace);
+        }
+
+        @Override
+        public void timeout(String duration) {
+            arguments.add("--timeout");
+            arguments.add(duration);
+        }
+
+        @Override
+        public void dryRun() {
+            arguments.add("--dry-run");
+        }
+
+        @Override
+        public void arguments(String... args) {
+            arguments.addAll(Arrays.asList(args));
+        }
+    }
+}

--- a/contentgrid-helm-client/src/test/java/com/contentgrid/helm/HelmIntegrationTest.java
+++ b/contentgrid-helm-client/src/test/java/com/contentgrid/helm/HelmIntegrationTest.java
@@ -55,5 +55,9 @@ class HelmIntegrationTest {
             assertThat(release.namespace()).isEqualTo(namespace.getMetadata().getName());
             assertThat(release.status()).isEqualTo("deployed");
         });
+
+        var uninstallResult = helm.uninstall().uninstall("nginx");
+
+        assertThat(helm.list().releases()).isEmpty();
     }
 }

--- a/contentgrid-junit-jupiter-k8s/src/main/java/com/contentgrid/junit/jupiter/helm/HelmChart.java
+++ b/contentgrid-junit-jupiter-k8s/src/main/java/com/contentgrid/junit/jupiter/helm/HelmChart.java
@@ -1,0 +1,53 @@
+package com.contentgrid.junit.jupiter.helm;
+
+import com.contentgrid.helm.Helm;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * {@code HelmChart} is an annotation to inject a specific chart for the {@link HelmClient} JUnit Jupiter extension
+ * <p>
+ * This annotation requires the {@link HelmClient @HelmClient} annotation, which creates the configured {@link Helm} instance.
+ * <p>
+ * The referenced chart gets copied to the temporary working directory of the {@link Helm} client and chart repositories
+ * are installed in the ephemeral repository list of the {@link Helm} client.
+ */
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface HelmChart {
+
+    /**
+     * A chart reference, a path to a packaged chart, a path to an unpacked chart directory or a URL
+     * <p>
+     * Local paths can be to the {@code Chart.yaml} or its containing directory.
+     * A directory on the host filesystem can be referenced using the {@code file:} prefix, a classpath resource using the {@code classpath:} prefix.
+     * <p>
+     *
+     * All other formats will be passed directly to {@code helm install}
+     * @return chart reference
+     */
+    String chart();
+
+    /**
+     * @return The namespace to install the helm chart into.
+     * <p>
+     * Defaults to using the namespace configured on the kubernetes client
+     * <p>
+     * When the {@link #NAMESPACE_ISOLATE} setting is used, an isolated namespace is created for the helm chart
+     */
+    String namespace() default NAMESPACE_DEFAULT;
+
+    String NAMESPACE_DEFAULT = "\0\0";
+    String NAMESPACE_ISOLATE = "\0\1";
+
+    /**
+     * Whether repositories from {@code Chart.yaml} should be automatically added to the {@link Helm} client.
+     * Defaults to {@code true}.
+     *
+     * @return if the repositories from {@code Chart.yaml} should be added
+     */
+    boolean addChartRepositories() default true;
+
+}

--- a/contentgrid-junit-jupiter-k8s/src/main/java/com/contentgrid/junit/jupiter/helm/HelmChartHandle.java
+++ b/contentgrid-junit-jupiter-k8s/src/main/java/com/contentgrid/junit/jupiter/helm/HelmChartHandle.java
@@ -1,0 +1,213 @@
+package com.contentgrid.junit.jupiter.helm;
+
+import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
+
+import com.contentgrid.helm.Helm;
+import com.contentgrid.helm.HelmDependencyCommand.HelmDependency;
+import com.contentgrid.helm.HelmInstallCommand.InstallOption;
+import com.contentgrid.helm.HelmInstallCommand.InstallResult;
+import com.contentgrid.helm.HelmUninstallCommand.UninstallOption;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Queue;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * A handle to a helm chart created by the {@link HelmChart @HelmChart} annotation.
+ * <p>
+ *
+ *
+ */
+@Slf4j
+@RequiredArgsConstructor(access = AccessLevel.PACKAGE)
+public class HelmChartHandle implements AutoCloseable {
+    private final Helm client;
+    private final HelmChart configuration;
+    private final ClassLoader classLoader;
+    private final Path tempDir;
+
+    private final Queue<InstallResult> installs = new LinkedList<>();
+
+    public InstallResult install(InstallOption... options) {
+        var newOptions = createAdditionalOptions();
+        newOptions.addAll(List.of(options));
+
+        var chartReference = getChartReference();
+
+        if(configuration.addChartRepositories()) {
+            chartReference.configureChartRepositories(client);
+        }
+
+        var path = chartReference.provisionChart(client);
+
+        var installResult = client.install().chart(path, newOptions.toArray(InstallOption[]::new));
+        installs.add(installResult);
+        return installResult;
+    }
+
+    private ChartReference getChartReference() {
+        var chart = configuration.chart();
+        var parsedLocation = ParsedChartLocation.parse(configuration.chart());
+
+        Optional<Path> localPath = switch (parsedLocation.type()) {
+            case CLASSPATH -> {
+                var classpathUrl = classLoader.getResource(parsedLocation.path());
+                if(classpathUrl == null) {
+                    throw new IllegalArgumentException("Chart '%s' not found".formatted(chart));
+                }
+                try {
+                    yield Optional.of(Path.of(classpathUrl.toURI()));
+                } catch (URISyntaxException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+            case FILE -> Optional.of(Path.of(parsedLocation.path()));
+            default -> Optional.empty();
+        };
+
+        return localPath.map(HelmChartHandle::chartBasePath)
+                .<ChartReference>map(path -> new LocalChartReference(path, tempDir))
+                .orElseGet(() -> new RemoteChartReference(parsedLocation.path()));
+    }
+
+    private List<InstallOption> createAdditionalOptions() {
+        List<InstallOption> options = new ArrayList<>();
+        options.add(InstallOption.generateName());
+
+        options.addAll(switch (configuration.namespace()) {
+            case HelmChart.NAMESPACE_DEFAULT -> List.of();
+            case HelmChart.NAMESPACE_ISOLATE -> {
+                var namespace = UUID.randomUUID();
+                yield List.of(
+                        InstallOption.namespace(namespace.toString()),
+                        InstallOption.createNamespace()
+                );
+            }
+            default -> List.of(InstallOption.namespace(configuration.namespace()));
+        });
+
+        return options;
+    }
+
+    @Override
+    public void close() {
+        if(installs.isEmpty()) {
+            log.warn("Helm chart '{}' was never installed. Don't forget to call HelmChartHandle.install() to install the helm chart.", configuration.chart());
+        }
+
+        while(!installs.isEmpty()) {
+            var install = installs.poll();
+
+            client.uninstall().uninstall(install.name(), UninstallOption.namespace(install.namespace()));
+        }
+    }
+
+    private sealed interface ChartReference {
+        void configureChartRepositories(Helm helm);
+        String provisionChart(Helm helm);
+    }
+
+    @RequiredArgsConstructor
+    private static final class LocalChartReference implements ChartReference {
+        private final Path path;
+        private final Path tempDir;
+
+        @Override
+        public void configureChartRepositories(Helm helm) {
+            helm.dependency().list(path)
+                    .stream()
+                    .map(HelmDependency::repository)
+                    // Deduplicate repositories
+                    .collect(Collectors.toUnmodifiableSet())
+                    .forEach(helm.repository()::add);
+        }
+
+        @Override
+        @SneakyThrows
+        public String provisionChart(Helm helm) {
+            var temp = Files.createTempDirectory(tempDir, path.getFileName().toString());
+            copyFolder(path, temp);
+
+            log.info("Installing dependencies");
+            helm.dependency().build(temp);
+            return temp.toAbsolutePath().toString();
+        }
+
+        @SneakyThrows
+        private static void copyFolder(Path src, Path dest) {
+            log.info("Copying chart from {} to {}", src.toAbsolutePath(), dest.toAbsolutePath());
+            try (Stream<Path> stream = Files.walk(src)) {
+                stream.forEach(source -> copy(source, dest.resolve(src.relativize(source))));
+            }
+        }
+
+        @SneakyThrows
+        private static void copy(Path source, Path dest) {
+            Files.copy(source, dest, REPLACE_EXISTING);
+        }
+
+    }
+
+    @RequiredArgsConstructor
+    private final class RemoteChartReference implements ChartReference {
+        private final String location;
+
+        @Override
+        public void configureChartRepositories(Helm helm) {
+
+        }
+
+        @Override
+        public String provisionChart(Helm helm) {
+            return location;
+        }
+    }
+
+    private static Path chartBasePath(Path location) {
+        if (Files.isDirectory(location) && Files.exists(location.resolve("Chart.yaml"))) {
+            return location;
+        } else if (Files.isRegularFile(location) && location.getFileName().toString()
+                .equals("Chart.yaml")) {
+            return location.getParent();
+        }
+        throw new IllegalArgumentException("No 'Chart.yaml' found at '%s'".formatted(location));
+    }
+
+
+    private record ParsedChartLocation(LocationType type, String path) {
+        enum LocationType {
+            CLASSPATH,
+            FILE,
+            OTHER
+        }
+
+        public static ParsedChartLocation parse(String location) {
+            var firstColon = location.indexOf(':');
+            var prefix = location.substring(0, firstColon);
+
+            var locationType = switch(prefix) {
+                case "classpath" -> LocationType.CLASSPATH;
+                case "file" -> LocationType.FILE;
+                default -> LocationType.OTHER;
+            };
+
+            if(locationType != LocationType.OTHER) {
+                location = location.substring(firstColon+1);
+            }
+
+            return new ParsedChartLocation(locationType, location);
+        }
+    }
+
+}

--- a/contentgrid-junit-jupiter-k8s/src/main/java/com/contentgrid/junit/jupiter/helm/HelmChartHandleExtension.java
+++ b/contentgrid-junit-jupiter-k8s/src/main/java/com/contentgrid/junit/jupiter/helm/HelmChartHandleExtension.java
@@ -1,0 +1,59 @@
+package com.contentgrid.junit.jupiter.helm;
+
+import static com.contentgrid.junit.jupiter.helpers.FieldHelper.findFields;
+import static com.contentgrid.junit.jupiter.helpers.FieldHelper.getFieldValue;
+import static com.contentgrid.junit.jupiter.helpers.FieldHelper.setFieldValue;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.List;
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+public class HelmChartHandleExtension implements HasHelmClient, BeforeEachCallback, BeforeAllCallback, AfterEachCallback,
+        AfterAllCallback{
+
+    private static List<Field> findTargetFields(ExtensionContext context, boolean isStatic)  {
+        return findFields(context, HelmChartHandle.class, f -> Modifier.isStatic(f.getModifiers()) == isStatic && f.isAnnotationPresent(HelmChart.class));
+    }
+
+    @Override
+    public void beforeAll(ExtensionContext context) throws Exception {
+        for (Field field : findTargetFields(context, true)) {
+            setFieldValue(field, null, createHelmChartHandle(field, context));
+        }
+    }
+
+    @Override
+    public void beforeEach(ExtensionContext context) throws Exception {
+        for (Field field : findTargetFields(context, false)) {
+            setFieldValue(field, context.getRequiredTestInstance(), createHelmChartHandle(field, context));
+        }
+    }
+
+    private HelmChartHandle createHelmChartHandle(Field field, ExtensionContext context) {
+        return new HelmChartHandle(
+                getHelmClient(context),
+                field.getAnnotation(HelmChart.class),
+                context.getRequiredTestClass().getClassLoader(),
+                workingDirectory(context)
+        );
+    }
+
+    @Override
+    public void afterAll(ExtensionContext context) throws Exception {
+        for (var field : findTargetFields(context, true)) {
+            ((HelmChartHandle)getFieldValue(field, null)).close();
+        }
+    }
+
+    @Override
+    public void afterEach(ExtensionContext context) throws Exception {
+        for (var field : findTargetFields(context, false)) {
+            ((HelmChartHandle)getFieldValue(field, context.getRequiredTestInstance())).close();
+        }
+    }
+}

--- a/contentgrid-junit-jupiter-k8s/src/main/java/com/contentgrid/junit/jupiter/helm/HelmClient.java
+++ b/contentgrid-junit-jupiter-k8s/src/main/java/com/contentgrid/junit/jupiter/helm/HelmClient.java
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
  */
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
-@ExtendWith(HelmClientExtension.class)
+@ExtendWith({HelmClientExtension.class, HelmChartHandleExtension.class})
 @Inherited
 public @interface HelmClient {
 

--- a/contentgrid-junit-jupiter-k8s/src/main/java/com/contentgrid/junit/jupiter/helm/HelmTest.java
+++ b/contentgrid-junit-jupiter-k8s/src/main/java/com/contentgrid/junit/jupiter/helm/HelmTest.java
@@ -16,12 +16,14 @@ import org.junit.jupiter.api.extension.ExtendWith;
  *
  * The referenced chart gets copied to the temporary working directory of the {@link Helm} client and chart repositories
  * are installed in the ephemeral repository list of the {@link Helm} client.
+ *
+ * @deprecated Use the {@link HelmChart @HelmChart} annotation on a {@link HelmChartHandle} field instead
  */
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
-@ExtendWith(HelmClientExtension.class)
-@ExtendWith(HelmTestExtension.class)
+@ExtendWith({HelmClientExtension.class, HelmChartHandleExtension.class, HelmTestExtension.class})
 @Inherited
+@Deprecated(since = "0.0.8", forRemoval = true)
 public @interface HelmTest {
 
     /**

--- a/contentgrid-junit-jupiter-k8s/src/main/java/com/contentgrid/junit/jupiter/helm/HelmTestExtension.java
+++ b/contentgrid-junit-jupiter-k8s/src/main/java/com/contentgrid/junit/jupiter/helm/HelmTestExtension.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.platform.commons.support.AnnotationSupport;
 
 @Slf4j
+@Deprecated(since = "0.0.8", forRemoval = true)
 public class HelmTestExtension implements HasHelmClient, BeforeAllCallback {
 
     @Override

--- a/contentgrid-junit-jupiter-k8s/src/main/java/com/contentgrid/junit/jupiter/helpers/FieldHelper.java
+++ b/contentgrid-junit-jupiter-k8s/src/main/java/com/contentgrid/junit/jupiter/helpers/FieldHelper.java
@@ -18,4 +18,20 @@ public class FieldHelper {
                 HierarchyTraversalMode.TOP_DOWN);
     }
 
+    public static Object getFieldValue(Field field, Object entity) throws IllegalAccessException {
+        var isAccessible = field.isAccessible();
+        try {
+            field.setAccessible(true);
+            return field.get(entity);
+        } finally {
+            field.setAccessible(isAccessible);
+        }
+    }
+
+    public static void setFieldValue(Field field, Object entity, Object value) throws IllegalAccessException {
+        final boolean isAccessible = field.isAccessible();
+        field.setAccessible(true);
+        field.set(entity, value);
+        field.setAccessible(isAccessible);
+    }
 }

--- a/contentgrid-junit-jupiter-k8s/src/test/java/com/contentgrid/junit/jupiter/helm/HelmClientExtensionTest.java
+++ b/contentgrid-junit-jupiter-k8s/src/test/java/com/contentgrid/junit/jupiter/helm/HelmClientExtensionTest.java
@@ -3,8 +3,10 @@ package com.contentgrid.junit.jupiter.helm;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.contentgrid.helm.Helm;
+import com.contentgrid.helm.HelmInstallCommand.InstallResult;
 import com.contentgrid.junit.jupiter.k8s.KubernetesTestCluster;
 import io.fabric8.kubernetes.api.model.Namespace;
+import java.util.List;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
@@ -59,6 +61,43 @@ class HelmClientExtensionTest {
                 assertThat(release.status()).isEqualTo("deployed");
             });
 
+        }
+    }
+
+    @Nested
+    @KubernetesTestCluster
+    @HelmClient
+    class HelmChartHandleTest {
+
+        @HelmChart(chart = "oci://registry-1.docker.io/bitnamicharts/nginx")
+        HelmChartHandle defaultChart;
+
+        @HelmChart(chart = "oci://registry-1.docker.io/bitnamicharts/nginx", namespace = HelmChart.NAMESPACE_ISOLATE)
+        HelmChartHandle isolatedChart;
+
+        @HelmChart(chart = "oci://registry-1.docker.io/bitnamicharts/nginx", namespace = "kube-system")
+        HelmChartHandle explicitNamespace;
+
+        @HelmChart(chart = "classpath:fixtures/app", namespace = HelmChart.NAMESPACE_ISOLATE)
+        HelmChartHandle appChart;
+
+        // random ephemeral namespace created by fabric8 junit-jupiter integration
+        Namespace namespace;
+
+        @Test
+        void testInstallHandles() {
+            var defaultResult = defaultChart.install();
+            var isolatedResult = isolatedChart.install();
+            var explicitNamespaceResult = explicitNamespace.install();
+
+            assertThat(defaultResult.namespace()).isEqualTo(namespace.getMetadata().getName());
+            assertThat(isolatedResult.namespace()).isNotEqualTo(defaultResult.namespace());
+            assertThat(explicitNamespaceResult.namespace()).isEqualTo("kube-system");
+        }
+
+        @Test
+        void installClasspathHandle() {
+            appChart.install();
         }
     }
 }


### PR DESCRIPTION
This replaces the confusing `@HelmTest` annotation and allows for more
flexibility for installing multiple helm charts
