### PR TITLE
Revert "Allow renovatebot to update external-secrets [ACC-2092]"

### DIFF
--- a/contentgrid-junit-jupiter-k8s/src/main/java/com/contentgrid/junit/jupiter/externalsecrets/ExternalSecretsExtension.java
+++ b/contentgrid-junit-jupiter-k8s/src/main/java/com/contentgrid/junit/jupiter/externalsecrets/ExternalSecretsExtension.java
@@ -5,6 +5,7 @@ import static com.contentgrid.junit.jupiter.k8s.K8sTestUtils.isCiliumNetworkPoli
 import static com.contentgrid.junit.jupiter.k8s.K8sTestUtils.waitUntilDeploymentsReady;
 import static org.apache.commons.lang3.RandomStringUtils.insecure;
 
+import com.contentgrid.helm.HelmInstallCommand.InstallOption;
 import com.contentgrid.junit.jupiter.helm.HasHelmClient;
 import io.fabric8.junit.jupiter.HasKubernetesClient;
 import java.lang.reflect.Field;
@@ -46,9 +47,7 @@ public class ExternalSecretsExtension implements HasHelmClient, HasKubernetesCli
         var helm = getHelmClient(context);
         // setup external-secrets-operator
         helm.repository().add("external-secrets", "https://charts.external-secrets.io");
-        var chartPath = ExternalSecretsExtension.class.getResource("/externalsecrets/chart").getPath();
-        helm.dependency().build(chartPath);
-        helm.install().chart("external-secrets", chartPath);
+        helm.install().chart("external-secrets", "external-secrets/external-secrets", InstallOption.version("v0.16.2"));
 
         // wait until expected deployments have available-replica
         waitUntilDeploymentsReady(2 * 60,

--- a/contentgrid-junit-jupiter-k8s/src/main/resources/externalsecrets/chart/Chart.yaml
+++ b/contentgrid-junit-jupiter-k8s/src/main/resources/externalsecrets/chart/Chart.yaml
@@ -1,8 +1,0 @@
-apiVersion: v2
-version: 0.1.0
-name: ExternalSecretsRenovateTarget
-description: "This chart is just for installing external-secrets, it's in a separate chart so that renovatebot can update the version of external-secrets."
-dependencies:
-  - name: external-secrets
-    version: 0.16.2
-    repository: "https://charts.external-secrets.io/"


### PR DESCRIPTION
Using a file embedded on the classpath does not work with helm, because helm is not able to read files packaged inside a jar.


Reverts xenit-eu/helm-integration-testing#30

```
com.contentgrid.helm.impl.CommandExecutor$CommandException: Error: could not find file:/home/lars/Documents/Projects/xenit/helm-integration-testing/contentgrid-junit-jupiter-k8s/build/libs/contentgrid-junit-jupiter-k8s-0.0.8-SNAPSHOT.jar!/externalsecrets/chart: stat file:/home/lars/Documents/Projects/xenit/helm-integration-testing/contentgrid-junit-jupiter-k8s/build/libs/contentgrid-junit-jupiter-k8s-0.0.8-SNAPSHOT.jar!/externalsecrets/chart: no such file or directory

	at com.contentgrid.helm.impl.CommandExecutor.call(CommandExecutor.java:36)
	at com.contentgrid.helm.impl.ProcessBuilderHelmExecutor.call(ProcessBuilderHelmExecutor.java:54)
	at com.contentgrid.helm.impl.CommandExecutor.call(CommandExecutor.java:22)
	at com.contentgrid.helm.impl.DefaultHelmDependencyCommand.build(DefaultHelmDependencyCommand.java:36)
	at com.contentgrid.junit.jupiter.externalsecrets.ExternalSecretsExtension.beforeAll(ExternalSecretsExtension.java:50)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
``