### PR TITLE
Workaround helm generating invalid release names for OCI

### DIFF
--- a/contentgrid-helm-client/src/main/java/com/contentgrid/helm/impl/DefaultHelmTemplateCommand.java
+++ b/contentgrid-helm-client/src/main/java/com/contentgrid/helm/impl/DefaultHelmTemplateCommand.java
@@ -38,7 +38,7 @@ class DefaultHelmTemplateCommand implements HelmTemplateCommand {
         // chart reference is required
         args.add(chart);
 
-        var handler = new DefaultTemplateFlagHandler(args, objectMapper);
+        var handler = new DefaultTemplateFlagHandler(args, objectMapper, !name.isEmpty());
 
         flags.forEach(flag -> {
             flag.apply(handler);
@@ -52,8 +52,8 @@ class DefaultHelmTemplateCommand implements HelmTemplateCommand {
 
 class DefaultTemplateFlagHandler extends DefaultInstallOptionsHandler implements TemplateFlagHandler {
 
-    public DefaultTemplateFlagHandler(@NonNull List<String> arguments, @NonNull ObjectMapper objectMapper) {
-        super(arguments, objectMapper);
+    public DefaultTemplateFlagHandler(@NonNull List<String> arguments, @NonNull ObjectMapper objectMapper, boolean hasName) {
+        super(arguments, objectMapper, hasName);
     }
 
     @Override

--- a/contentgrid-helm-client/src/test/java/com/contentgrid/helm/HelmIntegrationTest.java
+++ b/contentgrid-helm-client/src/test/java/com/contentgrid/helm/HelmIntegrationTest.java
@@ -56,8 +56,17 @@ class HelmIntegrationTest {
             assertThat(release.status()).isEqualTo("deployed");
         });
 
-        var uninstallResult = helm.uninstall().uninstall("nginx");
+        helm.uninstall().uninstall("nginx");
 
         assertThat(helm.list().releases()).isEmpty();
+    }
+
+    @Test
+    void installOCIWithGeneratedName() {
+        var result = helm.install()
+                .chart("oci://registry-1.docker.io/bitnamicharts/nginx:20.0.5");
+
+
+        helm.uninstall().uninstall(result.name());
     }
 }

--- a/contentgrid-junit-jupiter-k8s/src/main/java/com/contentgrid/junit/jupiter/helm/HelmChartHandle.java
+++ b/contentgrid-junit-jupiter-k8s/src/main/java/com/contentgrid/junit/jupiter/helm/HelmChartHandle.java
@@ -83,7 +83,6 @@ public class HelmChartHandle implements AutoCloseable {
 
     private List<InstallOption> createAdditionalOptions() {
         List<InstallOption> options = new ArrayList<>();
-        options.add(InstallOption.generateName());
 
         options.addAll(switch (configuration.namespace()) {
             case HelmChart.NAMESPACE_DEFAULT -> List.of();


### PR DESCRIPTION
OCI registries including tag generate an invalid release name (as per https://github.com/helm/helm/issues/30949)
