### PR TITLE
ACC-2685: Dump k8s event logs when test fails

### DIFF
--- a/contentgrid-junit-jupiter-k8s/src/main/java/com/contentgrid/junit/jupiter/k8s/log/KubernetesLoggerExtension.java
+++ b/contentgrid-junit-jupiter-k8s/src/main/java/com/contentgrid/junit/jupiter/k8s/log/KubernetesLoggerExtension.java
@@ -62,6 +62,9 @@ public class KubernetesLoggerExtension implements HasKubernetesClient, BeforeAll
             if(logger != null) {
                 logger.logs()
                         .forEachOrdered(line -> log.info("[{}] {} {} >>> {}", line.resource(), line.timestamp(), line.container(), line.line()));
+                logger.events()
+                        .forEachOrdered(event -> log.info("[{}] {} {} >>> [{}] {} (×{} in {}s)",
+                                event.resource(), event.timestamp(), event.type(), event.reason(), event.message(), event.repeat().count(), event.repeat().period().getSeconds()));
             }
         }
     }

--- a/contentgrid-junit-jupiter-k8s/src/main/java/com/contentgrid/junit/jupiter/k8s/log/KubernetesLoggerExtension.java
+++ b/contentgrid-junit-jupiter-k8s/src/main/java/com/contentgrid/junit/jupiter/k8s/log/KubernetesLoggerExtension.java
@@ -4,6 +4,7 @@ import static com.contentgrid.junit.jupiter.helpers.FieldHelper.findFields;
 import static com.contentgrid.junit.jupiter.helpers.FieldHelper.getFieldValue;
 
 import com.contentgrid.junit.jupiter.helpers.FieldHelper;
+import com.contentgrid.junit.jupiter.k8s.resource.AwaitableResource.Event.RepeatCount;
 import io.fabric8.junit.jupiter.HasKubernetesClient;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
@@ -63,10 +64,15 @@ public class KubernetesLoggerExtension implements HasKubernetesClient, BeforeAll
                 logger.logs()
                         .forEachOrdered(line -> log.info("[{}] {} {} >>> {}", line.resource(), line.timestamp(), line.container(), line.line()));
                 logger.events()
-                        .forEachOrdered(event -> log.info("[{}] {} {} >>> [{}] {} (×{} in {}s)",
-                                event.resource(), event.timestamp(), event.type(), event.reason(), event.message(), event.repeat().count(), event.repeat().period().getSeconds()));
+                        .forEachOrdered(event -> log.info("[{}] {} {} >>> [{}] {}{}",
+                                event.resource(), event.timestamp(), event.type(), event.reason(), event.message(),
+                                event.repeat().count() > 1 ? formatRepeatCount(event.repeat()) : ""));
             }
         }
+    }
+
+    private static String formatRepeatCount(RepeatCount repeat) {
+        return " (×%s in %ss)".formatted(repeat.count(), repeat.period().getSeconds());
     }
 
     @Override

--- a/contentgrid-junit-jupiter-k8s/src/main/java/com/contentgrid/junit/jupiter/k8s/log/KubernetesResourceLogger.java
+++ b/contentgrid-junit-jupiter-k8s/src/main/java/com/contentgrid/junit/jupiter/k8s/log/KubernetesResourceLogger.java
@@ -2,6 +2,7 @@ package com.contentgrid.junit.jupiter.k8s.log;
 
 import com.contentgrid.helm.HelmInstallCommand;
 import com.contentgrid.junit.jupiter.k8s.resource.AwaitableResource;
+import com.contentgrid.junit.jupiter.k8s.resource.AwaitableResource.Event;
 import com.contentgrid.junit.jupiter.k8s.resource.AwaitableResource.LogLine;
 import com.contentgrid.junit.jupiter.k8s.resource.ConfigurableResourceSet;
 import com.contentgrid.junit.jupiter.k8s.resource.ResourceMatcher;
@@ -48,6 +49,12 @@ public class KubernetesResourceLogger implements ResourceMatchingSpec<Kubernetes
         return resourceSet.stream()
                 .flatMap(AwaitableResource::logs)
                 .filter(logLine -> logLine.timestamp().isAfter(logsSince));
+    }
+
+    public Stream<Event> events() {
+        return resourceSet.stream()
+                .flatMap(AwaitableResource::events)
+                .filter(event -> event.timestamp().plus(event.repeat().period()).isAfter(logsSince));
     }
 
     @Override


### PR DESCRIPTION
Example log lines:
```
17:00:58.306 [Test worker] INFO com.contentgrid.junit.jupiter.k8s.log.KubernetesLoggerExtension -- [Pod 00000000-0000-0000-0000-000000000001/openpolicyagent-dd9d7cb4c-c7gq7] 2026-03-23T15:56:40Z Normal >>> [Started] Started container openpolicyagent
17:00:58.311 [Test worker] INFO com.contentgrid.junit.jupiter.k8s.log.KubernetesLoggerExtension -- [Pod 00000000-0000-0000-0000-000000000001/openpolicyagent-dd9d7cb4c-c7gq7] 2026-03-23T15:56:41Z Warning >>> [Unhealthy] Readiness probe failed: HTTP probe failed with statuscode: 500 (×4 in 21s)
```